### PR TITLE
Phase 55: Scanner Instruction Template Promotion

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,76 @@
+# AGENTS — carna-scis Scanner Instructions
+
+Status: `promoted_instruction_file`
+Owner: `Scanner Lane`
+Phase: `55`
+Runtime status: `inactive_by_default`
+Repository role: `scanner_source_code`
+
+## Repository Role
+
+`carnaverone/carna-scis` owns scanner/source tooling for hashing, verification, random data, hex encoding and local secret-pattern detection.
+
+It does not own Control Tower canon, Agent Fleet contracts, Cockpit operator UI, raw exports, private archives or final product payloads.
+
+## Allowed Work
+
+```yaml
+allowed_work:
+  - scanner_source_maintenance
+  - documentation_updates
+  - safe_test_design
+  - security_boundary_clarification
+  - local_only_scanner_rules
+  - build_notes_without_execution
+```
+
+## Forbidden Work
+
+```yaml
+forbidden_work:
+  - storing_real_secrets
+  - storing_raw_private_exports
+  - adding_network_exfiltration
+  - adding_external_service_dependency
+  - workflow_creation_without_review
+  - package_install_without_review
+  - direct_main_write
+  - force_push
+  - history_rewrite
+  - branch_deletion_without_explicit_review
+```
+
+## Scanner Policy
+
+```yaml
+scanner_policy:
+  scanner_execution_in_phase_55: false
+  local_only_design: true
+  network_access_required: false
+  raw_secret_output_allowed: false
+  masked_output_required: true
+```
+
+## PR Policy
+
+```yaml
+git_policy:
+  branch_required: true
+  draft_PR_required: true
+  compare_before_PR: true
+  comments_and_reviews_check_required: true
+  merge_with_expected_head_sha_required: true
+  force_push_allowed: false
+  history_rewrite_allowed: false
+```
+
+## Stop Conditions
+
+```yaml
+stop_conditions:
+  - requested_action_runs_scanner_on_private_data
+  - requested_action_stores_secret_or_raw_log
+  - requested_action_adds_network_upload
+  - requested_action_adds_unreviewed_workflow
+  - requested_action_changes_release_or_deployment
+```

--- a/CODEX.md
+++ b/CODEX.md
@@ -1,0 +1,69 @@
+# CODEX — carna-scis Local Coding Rules
+
+Status: `promoted_instruction_file`
+Owner: `Scanner Lane`
+Phase: `55`
+Runtime status: `inactive_by_default`
+Repository role: `scanner_source_code`
+
+## Purpose
+
+Define local coding-agent rules for `carna-scis`.
+
+These rules authorize safe documentation and source review work only. They do not authorize scanner execution on private data, package installation, workflows, release changes, deployment or external network behavior.
+
+## Local-first Rule
+
+```yaml
+local_first:
+  inspect_before_edit: true
+  preserve_existing_structure: true
+  avoid_unrelated_changes: true
+  no_direct_main_write: true
+  no_force_push: true
+  no_history_rewrite: true
+```
+
+## Command Policy
+
+```yaml
+command_policy:
+  destructive_commands_allowed: false
+  package_install_allowed_without_review: false
+  network_commands_allowed_without_review: false
+  scanner_execution_on_private_data_allowed: false
+  secret_scanning_before_commit_required: true
+```
+
+## File Policy
+
+```yaml
+file_policy:
+  allowed:
+    - markdown_documentation
+    - Zig_source_review
+    - local_scanner_docs
+    - redacted_test_notes
+  forbidden:
+    - real_env_files
+    - credentials
+    - raw_private_exports
+    - private_logs
+    - browser_sessions
+    - database_dumps
+    - generated_secret_reports
+```
+
+## Output Policy
+
+Every change must report:
+
+```yaml
+required_report:
+  - files_changed
+  - scope_confirmed
+  - runtime_status
+  - scanner_execution_status
+  - secret_status
+  - next_phase_or_blocker
+```

--- a/REPO_BOUNDARY.md
+++ b/REPO_BOUNDARY.md
@@ -1,0 +1,71 @@
+# Repository Boundary — carna-scis
+
+Status: `promoted_instruction_file`
+Owner: `Scanner Lane`
+Phase: `55`
+Runtime status: `inactive_by_default`
+Repository role: `scanner_source_code`
+
+## Repository Identity
+
+```yaml
+repository:
+  name: carnaverone/carna-scis
+  role: local_scanner_source_code
+  source_of_truth_for:
+    - Zig_scanner_source
+    - hash_verify_rand_hex_tools
+    - local_secret_pattern_detection
+    - scanner_documentation
+  not_source_of_truth_for:
+    - Control_Tower_canon
+    - Agent_Fleet_contracts
+    - Cockpit_operator_UI
+    - Export_Save_manifests
+    - raw_private_exports
+    - final_product_payloads
+```
+
+## Allowed Files
+
+```yaml
+allowed_file_families:
+  - README.md
+  - AGENTS.md
+  - REPO_BOUNDARY.md
+  - SECURITY.md
+  - CODEX.md
+  - LICENSE
+  - src/**
+  - build.zig
+  - docs/**
+```
+
+## Forbidden Files
+
+```yaml
+forbidden_file_families:
+  - .env
+  - secrets/**
+  - credentials/**
+  - raw_exports/**
+  - private_archives/**
+  - private_logs/**
+  - browser_sessions/**
+  - database_dumps/**
+```
+
+## Cross-repo Rule
+
+Scanner findings may be summarized as redacted reports. Raw private findings and secret values must not be committed.
+
+## Stop Before Proceeding
+
+```yaml
+stop_before_proceeding_if:
+  - file_contains_secret_or_token
+  - file_contains_raw_private_export
+  - change_adds_network_upload
+  - change_adds_unreviewed_workflow
+  - change_runs_scanner_on_private_material
+```

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,70 @@
+# Security — carna-scis
+
+Status: `promoted_instruction_file`
+Owner: `Scanner Lane`
+Phase: `55`
+Runtime status: `inactive_by_default`
+Repository role: `scanner_source_code`
+
+## Security Scope
+
+This repository contains local scanner source code and documentation.
+
+It must not contain real secrets, raw private exports, private logs, private archives, browser sessions, database dumps or unredacted scan findings.
+
+## Secret Policy
+
+```yaml
+secret_policy:
+  real_secrets_allowed: false
+  API_keys_allowed: false
+  OAuth_tokens_allowed: false
+  passwords_allowed: false
+  private_keys_allowed: false
+  browser_cookies_allowed: false
+  raw_env_files_allowed: false
+  placeholder_values_allowed: true
+  masked_examples_allowed: true
+```
+
+## Scanner Output Policy
+
+```yaml
+scanner_output_policy:
+  raw_secret_output_allowed: false
+  masked_output_required: true
+  private_scan_logs_allowed: false
+  redacted_summary_allowed: true
+```
+
+## Runtime Policy
+
+```yaml
+runtime_policy:
+  scanner_execution_in_phase_55: false
+  workflow_added: false
+  external_service_added: false
+  network_upload_added: false
+  package_install_added: false
+```
+
+## Review Gates
+
+```yaml
+review_gates:
+  before_scanner_execution_on_private_data:
+    - authorization_review
+    - data_scope_review
+    - output_redaction_review
+    - explicit_human_review
+
+  before_workflow_or_release_change:
+    - CI_scope_review
+    - secret_policy_review
+    - rollback_policy
+    - explicit_human_review
+```
+
+## Incident Rule
+
+If a real secret or private payload is detected in repository content, stop immediately. Do not copy it, do not expand it, do not move it to another file. Record only a redacted finding and require manual remediation.


### PR DESCRIPTION
Phase 55 scanner pack for `carna-scis`.

Purpose:
- Promote repo-specific instruction files into the scanner lane.
- Keep scanner execution inactive in this phase.
- Preserve local-only, masked-output, no-secret-storage boundaries.

Added:
- `AGENTS.md`
- `REPO_BOUNDARY.md`
- `SECURITY.md`
- `CODEX.md`

Scope:
- instruction files only
- no scanner execution
- no workflow
- no credentials
- no external service
- no package install
- no release change
- no deployment
- no branch deletion
- no force push
- no history rewrite

Diff scope: 4 files, scanner instruction promotion only.